### PR TITLE
Accident Stats

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -12,7 +12,7 @@ module Types
                                
     field :get_accident_stats, [Tfl::Entities::AccidentStats::DetailType], null: true do
       description 'Gets all accident details for accidents occuring in the specified year'
-      argument :year, Integer, required: true
+      argument :year, Integer, description: 'The year for which to filter the accidents on.', required: true
     end
 
     def journey_meta_modes

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -6,11 +6,23 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 
-    field :journey_meta_modes, [Tfl::Entities::ModeType], null: false,
-                               description: 'Gets a list of all of the available journey planner modes'
+    field :journey_meta_modes, [Tfl::Entities::ModeType], null: false do
+      description 'Gets a list of all of the available journey planner modes'
+    end
+                               
+    field :get_accident_stats, [Tfl::Entities::AccidentStats::DetailType], null: true do
+      description 'Gets all accident details for accidents occuring in the specified year'
+      argument :year, Integer, required: true
+    end
+
     def journey_meta_modes
-      @client = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'])
-      @client.journey.modes
+      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'])
+      @tfl.journey.modes
+    end
+
+    def get_accident_stats(params)
+      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'], log_level: 'ERROR')
+      @tfl.accident_stats.details(params[:year])
     end
   end
 end

--- a/spec/requests/graphql/accident_stats_spec.rb
+++ b/spec/requests/graphql/accident_stats_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Graphql::AccidentStats", type: :request do
           id
           lat
           lon
+          location
         }
       }
     )
@@ -54,6 +55,15 @@ RSpec.describe "Graphql::AccidentStats", type: :request do
       it 'returns a data array' do
         json = JSON.parse(response.body)
         expect(json).to include('data')
+      end
+
+      it 'returns Entities::Place objects' do
+        json = JSON.parse(response.body)
+        place = json['data']['getAccidentStats'][0]
+        expect(place).to include('id')
+        expect(place).to include('lat')
+        expect(place).to include('lon')
+        expect(place).to include('location')
       end
     end
 

--- a/spec/requests/graphql/accident_stats_spec.rb
+++ b/spec/requests/graphql/accident_stats_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+require 'json'
+
+RSpec.describe "Graphql::AccidentStats", type: :request do
+  let (:valid_query) do
+    %(
+      {
+        getAccidentStats(year:2015) {
+          id
+          lat
+          lon
+        }
+      }
+    )
+  end
+
+  let (:missing_year) do
+    %(
+      {
+        getAccidentStats() {
+          id
+          lat
+          lon
+        }
+      }
+    )
+  end
+
+
+  let (:invalid_year) do
+    %(
+      {
+        getAccidentStats(year: '2000') {
+          id
+          lat
+          lon
+        }
+      }
+    )
+  end
+
+  describe 'getAccidentStats' do
+    context 'with a year parameter' do
+      before do
+        VCR.use_cassette('accident_stats/authorised_client_details') do
+          post graphql_path, params: { query: valid_query }
+        end
+      end
+
+      it 'returns 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns a data array' do
+        json = JSON.parse(response.body)
+        expect(json).to include('data')
+      end
+    end
+
+    context 'without a year parameter' do
+      before do
+        VCR.use_cassette('accident_stats/authorised_client_details') do
+          post graphql_path, params: { query: missing_year }
+        end
+      end
+
+      it 'returns a 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns an errors array' do
+        json = JSON.parse(response.body)
+        expect(json).to include('errors')
+      end
+    end
+
+    context 'with a string as the year parameter' do
+      before do
+        VCR.use_cassette('accident_stats/authorised_client_details') do
+          post graphql_path, params: { query: invalid_year }
+        end
+      end
+
+      it 'returns a 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns an errors array' do
+        json = JSON.parse(response.body)
+        expect(json).to include('errors')
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Adds a GraphQL query for the [AccidentStats/{year}](https://api.tfl.gov.uk/swagger/ui/index.html?url=/swagger/docs/v1#!/AccidentStats/AccidentStats_Get) endpoint.

Closes #72 